### PR TITLE
Update sql-database-sync-data-between-sql-databases.md

### DIFF
--- a/articles/sql-database/scripts/sql-database-sync-data-between-sql-databases.md
+++ b/articles/sql-database/scripts/sql-database-sync-data-between-sql-databases.md
@@ -219,11 +219,7 @@ foreach ($tableSchema in $databaseSchema.Tables)
         $fullColumnName = $tableSchema.QuotedName + "." + $columnSchema.QuotedName
         if ($addAllColumns -or $MetadataList.Contains($fullColumnName))
         {
-            if ((-not $addAllColumns) -and $tableSchema.HasError)
-            {
-                Write-Host "Can't add column $fullColumnName to the sync schema" -foregroundcolor "Red"
-                Write-Host $tableSchema.ErrorId -foregroundcolor "Red"c            }
-            elseif ((-not $addAllColumns) -and $columnSchema.HasError)
+            if ($columnSchema.HasError)
             {
                 Write-Host "Can't add column $fullColumnName to the sync schema" -foregroundcolor "Red"
                 Write-Host $columnSchema.ErrorId -foregroundcolor "Red"


### PR DESCRIPTION
$tableSchema.HasError is not necessary to verify again, because on line 210 there is a continue.

$columnSchema.HasError must be verified despite the value of $addAllColumns. Because, if $addAllColumns is true, $columnSchema.HasError will not be controlled.