### PR TITLE
feminine singular “específica” to complement VM

### DIFF
--- a/articles/virtual-machines/windows/tutorial-manage-vm.md
+++ b/articles/virtual-machines/windows/tutorial-manage-vm.md
@@ -30,7 +30,7 @@ Las máquinas virtuales de Azure proporcionan un entorno informático completame
 > [!div class="checklist"]
 > * Crear y conectar elementos a una máquina virtual
 > * Seleccionar y usar imágenes de máquinas virtuales
-> * Ver y usar tamaños de una máquina virtual específicos
+> * Ver y usar tamaños de una máquina virtual específica
 > * Cambiar el tamaño de una máquina virtual
 > * Ver y entender el estado de las máquinas virtuales
 
@@ -283,7 +283,7 @@ En este tutorial, ha aprendido conceptos básicos sobre la creación y administr
 > [!div class="checklist"]
 > * Crear y conectar elementos a una máquina virtual
 > * Seleccionar y usar imágenes de máquinas virtuales
-> * Ver y usar tamaños de una máquina virtual específicos
+> * Ver y usar tamaños de una máquina virtual específica
 > * Cambiar el tamaño de una máquina virtual
 > * Ver y entender el estado de las máquinas virtuales
 

--- a/articles/virtual-machines/windows/tutorial-manage-vm.md
+++ b/articles/virtual-machines/windows/tutorial-manage-vm.md
@@ -30,7 +30,7 @@ Las máquinas virtuales de Azure proporcionan un entorno informático completame
 > [!div class="checklist"]
 > * Crear y conectar elementos a una máquina virtual
 > * Seleccionar y usar imágenes de máquinas virtuales
-> * Ver y usar tamaños de una máquina virtual específica
+> * Ver y usar tamaños específicos de una máquina virtual
 > * Cambiar el tamaño de una máquina virtual
 > * Ver y entender el estado de las máquinas virtuales
 
@@ -283,7 +283,7 @@ En este tutorial, ha aprendido conceptos básicos sobre la creación y administr
 > [!div class="checklist"]
 > * Crear y conectar elementos a una máquina virtual
 > * Seleccionar y usar imágenes de máquinas virtuales
-> * Ver y usar tamaños de una máquina virtual específica
+> * Ver y usar tamaños específicos de una máquina virtual
 > * Cambiar el tamaño de una máquina virtual
 > * Ver y entender el estado de las máquinas virtuales
 


### PR DESCRIPTION
Specific is an adjective complementing VM, not to sizes (given that the articles talks about the sizes of a specific VM, not about the specific sizes of a VM), in Spanish we adjust the adjective to the name it is complementing to. In this case it should be feminine singular “específica”, not masculine plural.