### PR TITLE
Explanatory text wrongly marked as code

### DIFF
--- a/articles/service-fabric/service-fabric-tutorial-dotnet-app-enable-https-endpoint.md
+++ b/articles/service-fabric/service-fabric-tutorial-dotnet-app-enable-https-endpoint.md
@@ -281,8 +281,9 @@ if ($cert -eq $null)
     }
 }
 
-Modify the *SetCertAccess.ps1* file properties to set **Copy to Output Directory** to "Copy if newer".
 ```
+
+Modify the *SetCertAccess.ps1* file properties to set **Copy to Output Directory** to "Copy if newer".
 
 ### <a name="run-the-setup-script-as-a-local-administrator"></a>Ejecución del script de instalación como administrador local
 


### PR DESCRIPTION
Other localized pages should probably be checked too