### PR TITLE
Fix missing

### DIFF
--- a/articles/azure-functions/functions-reference-python.md
+++ b/articles/azure-functions/functions-reference-python.md
@@ -149,7 +149,7 @@ def main(req: func.HttpRequest,
     logging.info(f'Python HTTP triggered function processed: {obj.read()}')
 ```
 
-Cuando se invoca la función, la solicitud HTTP se pasa a la función como `req`. Se recuperará una entrada de Azure Blob Storage según el _identificador_ de la dirección URL de la ruta y estará disponible como `obj` en el cuerpo de la función.
+Cuando se invoca la función, la solicitud HTTP se pasa a la función como `req`. Se recuperará una entrada de Azure Blob Storage según el _id_ de la dirección URL de la ruta y estará disponible como `obj` en el cuerpo de la función.
 
 ## <a name="outputs"></a>Salidas
 


### PR DESCRIPTION
Because `id` is a variable name ( `"route ":" items/{id}"`), it is incorrect to translate it.