### PR TITLE
Fix missing

### DIFF
--- a/articles/cognitive-services/LUIS/luis-container-configuration.md
+++ b/articles/cognitive-services/LUIS/luis-container-configuration.md
@@ -32,7 +32,7 @@ Este contenedor tiene las siguientes opciones de configuración:
 |--|--|--|
 |SÍ|[ApiKey](#apikey-setting)|Se usa para realizar un seguimiento de la información de facturación.|
 |Sin |[Application Insights](#applicationinsights-setting)|Le permite agregar compatibilidad con los datos de telemetría de [Azure Application Insights](https://docs.microsoft.com/azure/application-insights) al contenedor.|
-|SÍ|[Billing](#billing-setting)|Especifica el URI del punto de conexión del recurso de servicio en Azure.|
+|SÍ|[Facturación](#billing-setting)|Especifica el URI del punto de conexión del recurso de servicio en Azure.|
 |SÍ|[Eula](#eula-setting)| Indica que ha aceptado la licencia del contenedor.|
 |Sin |[Fluentd](#fluentd-settings)|Escribe el registro y, opcionalmente, los datos de métricas en un servidor de Fluentd.|
 |Sin |[Logging](#logging-settings)|Proporciona compatibilidad con el registro de ASP.NET Core al contenedor. |

--- a/articles/cognitive-services/LUIS/luis-container-configuration.md
+++ b/articles/cognitive-services/LUIS/luis-container-configuration.md
@@ -32,10 +32,10 @@ Este contenedor tiene las siguientes opciones de configuración:
 |--|--|--|
 |SÍ|[ApiKey](#apikey-setting)|Se usa para realizar un seguimiento de la información de facturación.|
 |Sin |[Application Insights](#applicationinsights-setting)|Le permite agregar compatibilidad con los datos de telemetría de [Azure Application Insights](https://docs.microsoft.com/azure/application-insights) al contenedor.|
-|SÍ|[Facturación](#billing-setting)|Especifica el URI del punto de conexión del recurso de servicio en Azure.|
+|SÍ|[Billing](#billing-setting)|Especifica el URI del punto de conexión del recurso de servicio en Azure.|
 |SÍ|[Eula](#eula-setting)| Indica que ha aceptado la licencia del contenedor.|
 |Sin |[Fluentd](#fluentd-settings)|Escribe el registro y, opcionalmente, los datos de métricas en un servidor de Fluentd.|
-|Sin |[Registro](#logging-settings)|Proporciona compatibilidad con el registro de ASP.NET Core al contenedor. |
+|Sin |[Logging](#logging-settings)|Proporciona compatibilidad con el registro de ASP.NET Core al contenedor. |
 |SÍ|[Mounts](#mount-settings)|Leer y escribir datos desde el equipo host al contenedor y del contenedor al equipo host.|
 
 > [!IMPORTANT]


### PR DESCRIPTION
Since it is an argument (proper noun), it should not be translated.