### PR TITLE
Typos on translation to Spanish

### DIFF
--- a/articles/azure-monitor/platform/autoscale-best-practices.md
+++ b/articles/azure-monitor/platform/autoscale-best-practices.md
@@ -48,8 +48,8 @@ Es recomendable tener cuidado a la hora de elegir los diferentes umbrales de esc
 
 *No se recomiendan* opciones de escalado automático como las de los siguientes ejemplos, con valores de umbral iguales o muy similares en condiciones de escalado o reducción horizontal:
 
-* Aumentar las instancias en 1 cuando el número de subprocesos < = 600
-* Disminuir las instancias en 1 cuando el número de subprocesos > = 600
+* Aumentar las instancias en 1 cuando el número de subprocesos > = 600
+* Disminuir las instancias en 1 cuando el número de subprocesos < = 600
 
 Veamos un ejemplo de lo que puede llevar a producir un comportamiento confuso. Considere la siguiente secuencia.
 
@@ -64,7 +64,7 @@ La estimación durante una reducción horizontal está diseñada para evitar sit
 Nuestra recomendación es establecer un margen suficiente entre el escalado horizontal y en los umbrales. Por ejemplo, echemos un vistazo a esta siguiente combinación de reglas, que es mejor.
 
 * Aumentar las instancias en 1 cuando el porcentaje de CPU > = 80
-* Disminuir las instancias en 1 cuando el porcentaje de CPU > = 60
+* Disminuir las instancias en 1 cuando el porcentaje de CPU < = 60
 
 En este caso  
 


### PR DESCRIPTION
Some of the greater than and less than were changed on the translation and are suggesting the opposite of the English version of the article. They seem to be typos:
English article:
1st change:
Increase instances by 1 count when Thread Count >= 600
Decrease instances by 1 count when Thread Count <= 600
2nd change:
· Increase instances by 1 count when CPU% >= 80
Decrease instances by 1 count when CPU% <= 60
Spanish article (original version):
1st change:
* Aumentar las instancias en 1 cuando el número de subprocesos < = 600
* Disminuir las instancias en 1 cuando el número de subprocesos > = 600
2nd change:
* Aumentar las instancias en 1 cuando el porcentaje de CPU > = 80
* Disminuir las instancias en 1 cuando el porcentaje de CPU > = 60
Spanish article (proposed changes):
1st change:
* Aumentar las instancias en 1 cuando el número de subprocesos > = 600
* Disminuir las instancias en 1 cuando el número de subprocesos < = 600
2nd change:
* Aumentar las instancias en 1 cuando el porcentaje de CPU > = 80
* Disminuir las instancias en 1 cuando el porcentaje de CPU < = 60

Información útil para hacer una sugerencia:
1. Vaya a [Quick Start Localization Style Guides(Guías de estilo de localización de inicio rápido)](https://docs.Microsoft.com/Globalization/Localization/styleguides) para comprobar las **diez reglas más importantes** de la guía de estilo de Microsoft.
2. Vaya a [Portal lingüístico de Microsoft](https://www.Microsoft.com/Language) para comprobar la **traducción normalizada de un término** en todos los productos de Microsoft.
