### PR TITLE
Typo in Spanish version

### DIFF
--- a/articles/azure-monitor/platform/autoscale-best-practices.md
+++ b/articles/azure-monitor/platform/autoscale-best-practices.md
@@ -64,7 +64,7 @@ La estimación durante una reducción horizontal está diseñada para evitar sit
 Nuestra recomendación es establecer un margen suficiente entre el escalado horizontal y en los umbrales. Por ejemplo, echemos un vistazo a esta siguiente combinación de reglas, que es mejor.
 
 * Aumentar las instancias en 1 cuando el porcentaje de CPU > = 80
-* Disminuir las instancias en 1 cuando el porcentaje de CPU > = 60
+* Disminuir las instancias en 1 cuando el porcentaje de CPU < = 60
 
 En este caso  
 


### PR DESCRIPTION
The recommendation in Spanish is still showing incorrect < > symbols in Spanish:
Incorrect:
* Aumentar las instancias en 1 cuando el porcentaje de CPU > = 80
* Disminuir las instancias en 1 cuando el porcentaje de CPU > = 60

Correct:
* Aumentar las instancias en 1 cuando el porcentaje de CPU > = 80
* Disminuir las instancias en 1 cuando el porcentaje de CPU < = 60

This was accepted back in Nov 20th, 2019 however it seems that only one of the changes was done:
https://github.com/MicrosoftDocs/azure-docs.es-es/pull/690

Información útil para hacer una sugerencia:
1. Vaya a [Quick Start Localization Style Guides(Guías de estilo de localización de inicio rápido)](https://docs.Microsoft.com/Globalization/Localization/styleguides) para comprobar las **diez reglas más importantes** de la guía de estilo de Microsoft.
2. Vaya a [Portal lingüístico de Microsoft](https://www.Microsoft.com/Language) para comprobar la **traducción normalizada de un término** en todos los productos de Microsoft.
