### PR TITLE
Upper case in first word in title

### DIFF
--- a/articles/storage/blobs/storage-blob-pageblob-overview.md
+++ b/articles/storage/blobs/storage-blob-pageblob-overview.md
@@ -196,7 +196,7 @@ La operación de concesión de blob establece y administra un bloqueo en un blob
 
 Además de API de REST enriquecidas, los blobs en páginas también proporcionan acceso compartido, durabilidad y seguridad mejorada. Trataremos esos beneficios con más detalle en los párrafos siguientes. 
 
-### <a name="concurrent-access"></a>simultáneo
+### <a name="concurrent-access"></a>Simultáneo
 
 La API REST del blob en páginas y su mecanismo de concesión permite que las aplicaciones accedan al blob en páginas desde varios clientes. Por ejemplo, supongamos que necesita crear un servicio en la nube distribuido que comparte los objetos de almacenamiento con varios usuarios. Podría tratarse de una aplicación web que sirve una extensa colección de imágenes a varios usuarios. Una opción para esta implementación es usar una máquina virtual con discos conectados. Las desventajas de esto son (i) la restricción de que un disco solo puede adjuntarse a una única máquina virtual, y esto limita la escalabilidad, la flexibilidad y aumenta los riesgos. Si hay un problema con la máquina virtual o el servicio que se ejecuta en la máquina virtual, no se podrá acceder a la imagen, debido a la concesión, hasta que esta expire o se interrumpa. Otra desventaja es (ii) el costo adicional de tener una máquina virtual de IaaS. 
 


### PR DESCRIPTION
The word "Simultáneo" was wrongly lowcased.
